### PR TITLE
Ability to define a default deploy script.

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -2,9 +2,10 @@
 
 # Expects the following environment variables to be set:
 #
-# $SSH_KEY: Private key to use when deploying.
-# $REPO:    The repo to deploy.
-# $BRANCH: The branch, tag, or sha to checkout.
+# $SSH_KEY:       Private key to use when deploying.
+# $REPO:          The repo to deploy.
+# $BRANCH:        The branch, tag, or sha to checkout.
+# $DEPLOY_SCRIPT: The content of a deploy script to use if the repo doesn't define one.
 
 echo "$SSH_KEY" > "$HOME/id_rsa"
 chmod 0600 "$HOME/id_rsa"
@@ -25,5 +26,10 @@ git fetch -q origin
 
 git reset -q --hard "origin/$BRANCH"
 
-# Run the projects deploy script.
-./script/deploy
+if [ -e ./script/deploy ]; then
+    ./script/deploy
+elif [ -n "$DEPLOY_SCRIPT" ]; then
+    eval "$DEPLOY_SCRIPT"
+else
+    exit -1
+fi

--- a/db/migrate/20130607204525_add_script_to_jobs.rb
+++ b/db/migrate/20130607204525_add_script_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddScriptToJobs < ActiveRecord::Migration
+  def change
+    add_column :jobs, :script, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130607204524) do
+ActiveRecord::Schema.define(:version => 20130607204525) do
 
   create_table "jobs", :force => true do |t|
     t.string   "repo"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(:version => 20130607204524) do
     t.integer  "exit_status"
     t.datetime "created_at",  :null => false
     t.datetime "updated_at",  :null => false
+    t.text     "script"
   end
 
 end

--- a/lib/shipr.rb
+++ b/lib/shipr.rb
@@ -1,4 +1,5 @@
 require 'pathname'
+require 'open-uri'
 require 'active_support/core_ext'
 require 'rack/force_json'
 
@@ -61,6 +62,23 @@ module Shipr
         Pusher.secret = uri.password
         Pusher.app_id = uri.path.gsub '/apps/', ''
         Pusher
+      end
+    end
+
+    # Public: An easy way to configure and fetch a default deploy script to
+    # use. Works great for hosting a deploy script in a gist.
+    #
+    # Examples
+    #
+    #   Shipr.default_script
+    #   # => "git push git@heroku.com:app.git HEAD:master"
+    #
+    # Returns the String content of the deploy script.
+    def default_script
+      @default_script ||= begin
+        uri = URI.parse(ENV['DEPLOY_SCRIPT_URL']) rescue nil
+        return nil unless uri
+        open(uri).read
       end
     end
 

--- a/lib/shipr/api.rb
+++ b/lib/shipr/api.rb
@@ -53,6 +53,7 @@ module Shipr
         requires :repo, type: String
         optional :config, type: Hash
         optional :branch, type: String
+        optional :script, type: String
       end
       post do
         present deploy(declared params)

--- a/lib/shipr/models/job.rb
+++ b/lib/shipr/models/job.rb
@@ -93,6 +93,10 @@ class Job < ActiveRecord::Base
     exit_status == 0
   end
 
+  def script
+    super || Shipr.default_script
+  end
+
   entity :id, :repo, :branch, :user, :config, :exit_status, :output do
     expose :done?, as: :done
     expose :success?, as: :success
@@ -130,6 +134,7 @@ private
       :repo,
       :branch,
       :config,
+      :script,
       to: :job
 
     # ===========
@@ -156,9 +161,10 @@ private
 
     def env
       config.merge \
-        'REPO'     => repo,
-        'BRANCH'   => branch,
-        'SSH_KEY'  => ENV['SSH_KEY']
+        'REPO'          => repo,
+        'BRANCH'        => branch,
+        'SSH_KEY'       => ENV['SSH_KEY'],
+        'DEPLOY_SCRIPT' => script
     end
 
   end

--- a/spec/unit/models/job_spec.rb
+++ b/spec/unit/models/job_spec.rb
@@ -13,6 +13,7 @@ describe Job do
     its(:branch) { should eq 'master' }
     its(:config) { should eq('ENVIRONMENT' => 'production') }
     its(:output) { should eq '' }
+    its(:script) { should eq nil }
   end
 
   describe '.complete!' do


### PR DESCRIPTION
This allows for a `DEPLOY_SCRIPT_URL` environment variable to be set, which will be fetched and used as the default deploy script if the repo doesn't define a ./script/deploy file.
