### PR TITLE
Webhook notifications.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,4 +51,5 @@ group :test do
   gem 'timecop'
   gem 'approvals'
   gem 'database_cleaner'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,8 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.7.0)
+    crack (0.4.1)
+      safe_yaml (~> 0.9.0)
     database_cleaner (1.2.0)
     descendants_tracker (0.0.1)
     diff-lcs (1.2.4)
@@ -147,6 +149,7 @@ GEM
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.3)
     rubyzip (0.9.9)
+    safe_yaml (0.9.5)
     sass (3.2.14)
     shotgun (0.9)
       rack (>= 1.0)
@@ -193,6 +196,9 @@ GEM
     warden-github (0.14.0)
       octokit (>= 1.22.0)
       warden (> 1.0)
+    webmock (1.13.0)
+      addressable (>= 2.2.7)
+      crack (>= 0.3.2)
 
 PLATFORMS
   ruby
@@ -227,3 +233,4 @@ DEPENDENCIES
   timecop
   unicorn (~> 4.6.2)
   warden
+  webmock

--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,6 @@ end
 
 namespace :jobs do
   task :test do
-    p Job.create(repo: 'git@github.com:remind101/shipr.git')
+    p Shipr::JobCreator.create(repo: 'git@github.com:remind101/shipr.git', notify: ['http://requestb.in/wdzpnuwe'])
   end
 end

--- a/lib/shipr.rb
+++ b/lib/shipr.rb
@@ -4,8 +4,9 @@ require 'active_support/core_ext'
 require 'rack/force_json'
 
 require 'shipr/warden'
-require 'shipr/consumers/output_consumer'
-require 'shipr/consumers/completion_consumer'
+require 'shipr/consumers/worker_output_consumer'
+require 'shipr/consumers/worker_completion_consumer'
+require 'shipr/consumers/webhooks_consumer'
 require 'shipr/consumers/pusher_consumer'
 
 module Shipr
@@ -17,6 +18,7 @@ module Shipr
   autoload :JobOutputAppender, 'shipr/job_output_appender'
   autoload :JobRestarter,      'shipr/job_restarter'
   autoload :DeployTask,        'shipr/deploy_task'
+  autoload :WebhookNotifier,   'shipr/webhook_notifier'
 
   module Hooks
     autoload :Pusher, 'shipr/hooks/pusher'

--- a/lib/shipr/api.rb
+++ b/lib/shipr/api.rb
@@ -51,6 +51,7 @@ module Shipr
         optional :config, type: Hash
         optional :branch, type: String
         optional :script, type: String
+        optional :notify, type: Array[String]
       end
       post do
         present deploy(declared params)

--- a/lib/shipr/consumers/webhooks_consumer.rb
+++ b/lib/shipr/consumers/webhooks_consumer.rb
@@ -1,12 +1,14 @@
 module Shipr
   module Consumers
-    class OutputConsumer
+    class WebhooksConsumer
       include Hutch::Consumer
-      consume 'job.output'
+      consume 'job.complete'
 
       def process(message)
         job = Job.find(message[:id])
-        job.append_output!(message[:output])
+        job.notify.each do |url|
+          WebhookNotifier.notify(url, job)
+        end
       end
     end
   end

--- a/lib/shipr/consumers/worker_completion_consumer.rb
+++ b/lib/shipr/consumers/worker_completion_consumer.rb
@@ -1,0 +1,13 @@
+module Shipr
+  module Consumers
+    class WorkerCompletionConsumer
+      include Hutch::Consumer
+      consume 'worker.complete'
+
+      def process(message)
+        job = Job.find(message[:id])
+        job.complete!(message[:exit_status])
+      end
+    end
+  end
+end

--- a/lib/shipr/consumers/worker_output_consumer.rb
+++ b/lib/shipr/consumers/worker_output_consumer.rb
@@ -1,12 +1,12 @@
 module Shipr
   module Consumers
-    class CompletionConsumer
+    class WorkerOutputConsumer
       include Hutch::Consumer
-      consume 'job.complete'
+      consume 'worker.output'
 
       def process(message)
         job = Job.find(message[:id])
-        job.complete!(message[:exit_status])
+        job.append_output!(message[:output])
       end
     end
   end

--- a/lib/shipr/job.rb
+++ b/lib/shipr/job.rb
@@ -10,6 +10,7 @@ module Shipr
     field :output, type: String, default: ''
     field :exit_status, type: Integer
     field :script, type: String
+    field :notify, type: Array, default: []
 
     def id
       _id.to_s

--- a/lib/shipr/job_completer.rb
+++ b/lib/shipr/job_completer.rb
@@ -14,6 +14,7 @@ module Shipr
     def complete
       job.update_attributes!(exit_status: exit_status)
       trigger
+      Shipr.publish('job.complete', id: job.id)
     end
 
   private
@@ -21,6 +22,5 @@ module Shipr
     def trigger
       Shipr.push(job.channel, 'complete', job.entity)
     end
-
   end
 end

--- a/lib/shipr/webhook_notifier.rb
+++ b/lib/shipr/webhook_notifier.rb
@@ -1,0 +1,20 @@
+module Shipr
+  class WebhookNotifier
+    attr_reader :url, :job
+
+    def initialize(url, job)
+      @url = url
+      @job = job
+    end
+
+    def self.notify(*args)
+      new(*args).notify
+    end
+
+    def notify
+      Faraday.post(url, job.entity.to_json) do |req|
+        req.headers['Content-Type'] = 'application/json'
+      end
+    end
+  end
+end

--- a/spec/shipr/job_completer_spec.rb
+++ b/spec/shipr/job_completer_spec.rb
@@ -14,5 +14,11 @@ describe Shipr::JobCompleter do
       Shipr.should_receive(:push).with(kind_of(String), 'complete', kind_of(Shipr::Job::Entity))
       job_completer.complete
     end
+
+    it 'publishes a message' do
+      Shipr.stub(:push)
+      Shipr.should_receive(:publish).with('job.complete', id: job.id)
+      job_completer.complete
+    end
   end
 end

--- a/spec/shipr/job_spec.rb
+++ b/spec/shipr/job_spec.rb
@@ -66,4 +66,12 @@ describe Shipr::Job do
 
     it { should eq "private-job-#{job.id}" }
   end
+
+  describe '#webhooks' do
+    subject { job.notify }
+
+    context 'by default' do
+      it { should eq [] }
+    end
+  end
 end

--- a/spec/shipr/webhook_notifier_spec.rb
+++ b/spec/shipr/webhook_notifier_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Shipr::WebhookNotifier do
+  let(:url) { 'http://webhook.test' }
+  let(:job) { Shipr::Job.create exit_status: 1 }
+  subject(:notifier) { described_class.new(url, job) }
+
+  describe '#notify' do
+    it 'it sends a post request to the url with the entity' do
+      stub_request(:post, url)
+      notifier.notify
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,7 @@
 ENV['RACK_ENV'] = 'test'
+require 'webmock/rspec'
+
+WebMock.disable_net_connect!(allow_localhost: true)
 
 require File.expand_path('../../config/environment', __FILE__)
 

--- a/workers/deploy.rb
+++ b/workers/deploy.rb
@@ -19,10 +19,10 @@ class Deploy
     Open3.popen2e(options['env'], 'deploy') do |stdin, output, wait_thr|
       output.each do |line|
         puts line
-        publish('job.output', output: line)
+        publish('worker.output', output: line)
       end
       exit_status = wait_thr.value
-      publish('job.complete', exit_status: exit_status.to_i)
+      publish('worker.complete', exit_status: exit_status.to_i)
     end
   end
 


### PR DESCRIPTION
Allows you to provide an array of urls to send a POST request to when the deploy completes, so we can have the robut-shipr plugin notify hipchat.
