### PR TITLE
Retry the connection

### DIFF
--- a/workers/deploy.rb
+++ b/workers/deploy.rb
@@ -4,15 +4,14 @@ require 'time'
 require 'bunny'
 
 class Deploy
+  RETRIES    = 3 # times
+  RETRY_WAIT = 5 # seconds
+
   attr_reader :options
 
   def initialize(options)
     @options = options
-
-    conn = Bunny.new(options['rabbitmq']['url'])
-    conn.start
-    ch = conn.create_channel
-    @exchange = ch.topic(options['rabbitmq']['exchange'], durable: true)
+    connect
   end
 
   def run
@@ -28,6 +27,24 @@ class Deploy
 
 private
   attr_reader :exchange
+
+  def connect
+    retries = RETRIES
+
+    begin
+      conn = Bunny.new(options['rabbitmq']['url'])
+      conn.start
+      ch = conn.create_channel
+      @exchange = ch.topic(options['rabbitmq']['exchange'], durable: true)
+    rescue Bunny::TCPConnectionFailed
+      if retries > 0
+        retries -= 1
+        sleep RETRY_WAIT
+        retry
+      end
+      raise
+    end
+  end
 
   def publish(routing_key, message)
     message = { id: options['id'], time: Time.now.utc.iso8601 }.merge(message)


### PR DESCRIPTION
Occasionally see these:

```
Message: Occurred during run: /task/__gems__/gems/bunny-1.1.2/lib/bunny/transport.rb:246:in `rescue in initialize_socket': Could not establish TCP connection to 127.0.0.1:5672: (Bunny::TCPConnectionFailed)

from /task/__gems__/gems/bunny-1.1.2/lib/bunny/transport.rb:238:in `initialize_socket'
from /task/__gems__/gems/bunny-1.1.2/lib/bunny/transport.rb:253:in `maybe_initialize_socket'
from /task/__gems__/gems/bunny-1.1.2/lib/bunny/transport.rb:50:in `initialize'
```
