### PR TITLE
NewRelic deployment notifier.

### DIFF
--- a/notifier/newrelic/newrelic.go
+++ b/notifier/newrelic/newrelic.go
@@ -37,6 +37,11 @@ type Notifier struct {
 }
 
 func (n *Notifier) Notify(p *notifier.Notification) error {
+	// Only create deployments if it's successful.
+	if p.State != notifier.StatusSuccess {
+		return nil
+	}
+
 	var data DeploymentForm
 	data.Deployment.AppName = appName(p)
 	data.Deployment.Revision = p.Sha

--- a/notifier/newrelic/newrelic.go
+++ b/notifier/newrelic/newrelic.go
@@ -1,0 +1,86 @@
+package newrelic
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/remind101/tugboat/notifier"
+)
+
+const DefaultURL = "https://api.newrelic.com/deployments.xml"
+
+var _ notifier.Notifier = &Notifier{}
+
+type DeploymentForm struct {
+	Deployment struct {
+		AppName     string `json:"app_name"`
+		Description string `json:"description"`
+		Revision    string `json:"revision"`
+		Changelog   string `json:"changelog"`
+		User        string `json:"user"`
+	} `json:"deployment"`
+}
+
+// Notifier is a Notifier implementation that tracks deployment events in New
+// Relic.
+type Notifier struct {
+	// Key is the new relic API key.
+	Key string
+
+	// The URL to POST deployments to. Zero value is DefaultURL.
+	URL string
+
+	client *http.Client
+}
+
+func (n *Notifier) Notify(p *notifier.Notification) error {
+	var data DeploymentForm
+	data.Deployment.AppName = appName(p)
+	data.Deployment.Revision = p.Sha
+	data.Deployment.User = p.User
+
+	raw, err := json.Marshal(&data)
+	if err != nil {
+		return err
+	}
+
+	url := n.URL
+	if url == "" {
+		url = DefaultURL
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(raw))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("X-API-Key", n.Key)
+	req.Header.Set("Content-Type", "application/json")
+
+	c := n.client
+	if c == nil {
+		c = http.DefaultClient
+	}
+
+	_, err = c.Do(req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func appName(p *notifier.Notification) string {
+	parts := strings.Split(p.Repo, "/")
+	app := parts[1]
+
+	env := p.Environment
+	if env == "production" {
+		env = "prod"
+	}
+
+	return fmt.Sprintf("%s-%s", app, env)
+}

--- a/notifier/newrelic/newrelic_test.go
+++ b/notifier/newrelic/newrelic_test.go
@@ -23,7 +23,8 @@ func TestNotifier(t *testing.T) {
 	n := &Notifier{URL: s.URL, Key: "1234"}
 
 	if err := n.Notify(&notifier.Notification{
-		Repo: "remind101/acme-inc",
+		Repo:  "remind101/acme-inc",
+		State: "success",
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/notifier/newrelic/newrelic_test.go
+++ b/notifier/newrelic/newrelic_test.go
@@ -1,0 +1,53 @@
+package newrelic
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/remind101/tugboat/notifier"
+)
+
+func TestNotifier(t *testing.T) {
+	var called bool
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+
+		if got, want := r.Header.Get("X-API-Key"), "1234"; got != want {
+			t.Fatalf("API Key => %s; want %s", got, want)
+		}
+	}))
+	defer s.Close()
+
+	n := &Notifier{URL: s.URL, Key: "1234"}
+
+	if err := n.Notify(&notifier.Notification{
+		Repo: "remind101/acme-inc",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !called {
+		t.Fatal("No deployments created")
+	}
+}
+
+func TestAppName(t *testing.T) {
+	tests := []struct {
+		in  notifier.Notification
+		out string
+	}{
+		{notifier.Notification{Repo: "remind101/acme-inc", Environment: "production"}, "acme-inc-prod"},
+		{notifier.Notification{Repo: "remind101/acme-inc", Environment: "staging"}, "acme-inc-staging"},
+		{notifier.Notification{Repo: "remind101/acme-inc", Environment: "other"}, "acme-inc-other"},
+	}
+
+	for _, tt := range tests {
+		out := appName(&tt.in)
+
+		if got, want := out, tt.out; got != want {
+			t.Fatalf("appName => %s; want %s", got, want)
+		}
+	}
+}


### PR DESCRIPTION
Adds a Notifier implementation that creates new relic deployments using the v2 api.

Closes https://github.com/remind101/tugboat/issues/32