### PR TITLE
Update build script

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -2,8 +2,8 @@
 
 set -e
 
-echo "@edge http://dl-4.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
-packages="curl git go@edge"
+echo "@edge-community http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+packages="curl git go@edge-community"
 
 apk add --update $packages
 

--- a/bin/build
+++ b/bin/build
@@ -5,7 +5,7 @@ set -e
 echo "@edge http://dl-4.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
 packages="curl git go@edge"
 
-apk add --update curl git go@edge
+apk add --update $packages
 
 GOPATH=/go go get github.com/tools/godep
 cd /go/src/github.com/remind101/tugboat

--- a/bin/build
+++ b/bin/build
@@ -2,6 +2,7 @@
 
 set -e
 
+echo "hosts: files dns" >> /etc/nsswitch.conf
 echo "@edge-community http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 packages="curl git go@edge-community"
 


### PR DESCRIPTION
Updates the build script used in Docker image to fix the following:
 - Install go package from edge/community(latest in base is 1.3.3, which tugboat does not support)
 - Add nsswitch.conf(which is missing in alpine base) to ensure container links are resolved correctly