### PR TITLE
include deployment times in API and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ POST /deployments/:id/status
 
 ## Setup
 
-**TODO**
+1. Git clone this repo into `$GOPATH/src/github.com/remind101/tugboat`
+2. Run the `before_install` steps in `.travis.yml` to set up dependencies and env.
+3. Run the `script` steps in `.travis.yml` to test your setup.
 
 ## Roadmap
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,24 @@
+machine:
+  timezone: America/Los_Angeles
+  services:
+    - postgresql
+
+checkout:
+  post:
+    - rm -rf ~/.go_workspace/src/github.com/remind101
+    - mkdir -p ~/.go_workspace/src/github.com/remind101
+    - cp -R ~/tugboat ~/.go_workspace/src/github.com/remind101/tugboat
+
+dependencies:
+  pre:
+    - go install -a -race std
+    - go get github.com/tools/godep
+    - createdb tugboat
+    - cd ~/.go_workspace/src/github.com/remind101/tugboat && godep go install ./cmd/...
+    - cd ~/.go_workspace/src/github.com/remind101/tugboat && tugboat migrate
+
+
+test:
+  override:
+    - cd ~/.go_workspace/src/github.com/remind101/tugboat && make cmd
+    - cd ~/.go_workspace/src/github.com/remind101/tugboat && godep go test -race ./...

--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -431,6 +431,8 @@ module.run(['$templateCache', function($templateCache) {
     '      <th>Environment</th>\n' +
     '      <th>Provider</th>\n' +
     '      <th>Status</th>\n' +
+    '      <th>Started At</th>\n' +
+    '      <th>Completed At</th>\n' +
     '    </tr>\n' +
     '  </thead>\n' +
     '  <tbody>\n' +
@@ -444,6 +446,8 @@ module.run(['$templateCache', function($templateCache) {
     '    <td ng-bind="job.environment" title="{{ job.environment }}"></td>\n' +
     '    <td ng-bind="job.provider" title="{{ job.provider }}"></td>\n' +
     '    <td ng-bind="job.status"></td>\n' +
+    '    <td ng-bind="job.startedAt"></td>\n' +
+    '    <td ng-bind="job.completedAt"></td>\n' +
     '  </tr>\n' +
     '  </tbody>\n' +
     '</table>\n' +

--- a/frontend/templates/jobs/list.html
+++ b/frontend/templates/jobs/list.html
@@ -9,6 +9,8 @@
       <th>Environment</th>
       <th>Provider</th>
       <th>Status</th>
+      <th>Started At</th>
+      <th>Completed At</th>
     </tr>
   </thead>
   <tbody>
@@ -22,6 +24,8 @@
     <td ng-bind="job.environment" title="{{ job.environment }}"></td>
     <td ng-bind="job.provider" title="{{ job.provider }}"></td>
     <td ng-bind="job.status"></td>
+    <td ng-bind="job.startedAt"></td>
+    <td ng-bind="job.completedAt"></td>
   </tr>
   </tbody>
 </table>

--- a/server/api/deployments.go
+++ b/server/api/deployments.go
@@ -4,23 +4,27 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/remind101/tugboat"
 )
 
 type Deployment struct {
-	ID          string `json:"id"`
-	GitHubID    int64  `json:"github_id"`
-	User        string `json:"user"`
-	Repo        string `json:"repo"`
-	Sha         string `json:"sha"`
-	Ref         string `json:"ref"`
-	Environment string `json:"environment"`
-	Status      string `json:"status"`
-	Output      string `json:"output"`
-	Error       string `json:"error"`
-	Provider    string `json:"provider"`
+	ID          string     `json:"id"`
+	GitHubID    int64      `json:"github_id"`
+	User        string     `json:"user"`
+	Repo        string     `json:"repo"`
+	Sha         string     `json:"sha"`
+	Ref         string     `json:"ref"`
+	Environment string     `json:"environment"`
+	Status      string     `json:"status"`
+	Output      string     `json:"output"`
+	Error       string     `json:"error"`
+	Provider    string     `json:"provider"`
+	CreatedAt   time.Time  `json:"createdAt"` // always set
+	StartedAt   *time.Time `json:"startedAt"` // nil until started
+	CompletedAt *time.Time `json:"completedAt"`
 }
 
 func newDeployment(d *tugboat.Deployment) *Deployment {
@@ -35,6 +39,9 @@ func newDeployment(d *tugboat.Deployment) *Deployment {
 		Status:      d.Status.String(),
 		Error:       d.Error,
 		Provider:    d.Provider,
+		CreatedAt:   d.CreatedAt,
+		StartedAt:   d.StartedAt,
+		CompletedAt: d.CompletedAt,
 	}
 }
 

--- a/tests/api/api_test.go
+++ b/tests/api/api_test.go
@@ -42,6 +42,14 @@ func TestDeploymentsCreate(t *testing.T) {
 	if got, want := d.Provider, "heroku"; got != want {
 		t.Fatalf("Provider => %s; want %s", got, want)
 	}
+
+	if d.StartedAt == nil {
+		t.Fatalf("expected StartedAt to not be nil")
+	}
+
+	if d.CompletedAt != nil {
+		t.Fatalf("expected CompletedAt to be nil")
+	}
 }
 
 func TestDeploymentsCreate_Unauthorized(t *testing.T) {


### PR DESCRIPTION
It would help to have the start and completion times shown in the UI's table of deployments.

I haven't written Go before so please give feedback on best practices. I couldn't figure out how to test the value of startedAt because it pulls from Time.now().