### PR TITLE
Close with error

### DIFF
--- a/deployments.go
+++ b/deployments.go
@@ -70,7 +70,7 @@ func NewDeployOptsFromReader(r io.Reader) (DeployOpts, error) {
 // StatusUpdate is used to update the status of a Deployment.
 type StatusUpdate struct {
 	Status DeploymentStatus
-	Error  *error
+	Error  *string
 }
 
 // DeploymentStatus represents the status of a deployment.

--- a/tugboat.go
+++ b/tugboat.go
@@ -131,7 +131,7 @@ func (t *Tugboat) UpdateStatus(d *Deployment, update StatusUpdate) error {
 	case StatusErrored:
 		var err error
 		if update.Error != nil {
-			err = *update.Error
+			err = errors.New(*update.Error)
 		} else {
 			err = errors.New("no error provided")
 		}
@@ -274,8 +274,9 @@ func statusUpdate(fn func() error) (update StatusUpdate) {
 		if err == ErrFailed {
 			update.Status = StatusFailed
 		} else {
+			msg := err.Error()
 			update.Status = StatusErrored
-			update.Error = &err
+			update.Error = &msg
 		}
 	}()
 

--- a/tugboat.go
+++ b/tugboat.go
@@ -228,8 +228,11 @@ func deploy(ctx context.Context, opts DeployOpts, p Provider, t client) (deploym
 
 	logsDone := make(chan struct{}, 1)
 	go func() {
-		// we're ignoring err here.
-		_ = t.WriteLogs(deployment, r)
+		if werr := t.WriteLogs(deployment, r); werr != nil {
+			// If there was an error writing the logs, close the
+			// Write side of the pipe.
+			r.CloseWithError(err)
+		}
 		close(logsDone)
 	}()
 

--- a/tugboat_test.go
+++ b/tugboat_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestUpdateStatus(t *testing.T) {
-	boom := errors.New("boom")
+	boom := "boom"
 
 	tests := []struct {
 		fn     func() error
@@ -31,7 +31,7 @@ func TestUpdateStatus(t *testing.T) {
 		},
 		{
 			fn: func() error {
-				return boom
+				return errors.New(boom)
 			},
 			status: StatusUpdate{
 				Status: StatusErrored,


### PR DESCRIPTION
Previously, when calling `Deploy` it was possible for writes to the provided io.Writer to be silenced because the call to WriteLogs failed. This closes the Write side of the pipe with an error if WriteLogs fails.

This also changes the type of the `Error` field on the `StatusUpdate` struct to `*string`, since `*error` can't be json.Marshal/Unmarshaled.